### PR TITLE
Implement rate limiting retryer

### DIFF
--- a/pkg/aws/config/config.go
+++ b/pkg/aws/config/config.go
@@ -4,10 +4,15 @@ import (
 	"context"
 
 	"github.com/aws/aws-sdk-go-v2/aws"
+	"github.com/aws/aws-sdk-go-v2/aws/retry"
 	"github.com/aws/aws-sdk-go-v2/config"
 )
 
 // New creates a new aws.Config with custom endpoint resolver and region set
 func New(region string) (aws.Config, error) {
-	return config.LoadDefaultConfig(context.TODO(), config.WithRegion(region))
+	retrier := func() aws.Retryer {
+		return retry.NewAdaptiveMode()
+	}
+
+	return config.LoadDefaultConfig(context.TODO(), config.WithRegion(region), config.WithRetryer(retrier))
 }


### PR DESCRIPTION
When receiving a rate limit response from AWS, the application would exit with an error. This was an undesirable outcome.

AWS has a feature to implement retrying using their `retry` [package][1].

By default there are a number of retryable conditions. The relevant useful cases are as follows:

- Connection Errors
- RequestTimeout, RequestTimeoutException
- Throttling, ThrottlingException, ThrottledException, RequestThrottledException, TooManyRequestsException, RequestThrottled, SlowDown
- RequestLimitExceeded, BandwidthLimitExceeded, LimitExceededException

This means the default retryer will handle rate limiting and will not need to implicitly handle this case.

It is also important to note the following about client rate limiting:

> Generally you will always want to return new instance of a Retryer.
> This will avoid a global rate limit bucket being shared across all
> service clients.

This means that the instantiation of the S3 client must be handled within each Go routine and cannot be shared as it was previously implemented.

`AdaptiveMode` is the retry strategy that will be used:

> AdaptiveMode provides an experimental retry strategy that expands on
> the Standard retry strategy, adding client attempt rate limits. The
> attempt rate limit is initially unrestricted, but becomes restricted
> when the attempt fails with for a throttle error.

The default, values for the `AdaptiveMode` is based on the `NewStandard` which is:

- `DefaultMaxAttempts`: `3`
- `DefaultMaxBackoff`: `20s`

Fixes: #21 

[1]: https://pkg.go.dev/github.com/aws/aws-sdk-go-v2/aws/retry