### PR TITLE
Fix incorrectly named function

### DIFF
--- a/internal/pkg/workers/s3_test.go
+++ b/internal/pkg/workers/s3_test.go
@@ -470,7 +470,7 @@ func (s S3ServiceMock) PutObjectSimple(ctx context.Context, bucketName string, k
 	return nil, nil, nil
 }
 
-func (s S3ServiceMock) GetBucektRegion(ctx context.Context, bucketName string) (string, error) {
+func (s S3ServiceMock) GetBucketRegion(ctx context.Context, bucketName string) (string, error) {
 	return "", nil
 }
 

--- a/main.go
+++ b/main.go
@@ -116,7 +116,7 @@ func main() {
 		loadingSpinner.Start()
 	}
 	log.Debug().Msg("s3: get bucket region")
-	bucketRegion, err := s3svc.GetBucektRegion(ctx, selectedBucket)
+	bucketRegion, err := s3svc.GetBucketRegion(ctx, selectedBucket)
 	loadingSpinner.Stop()
 	if err != nil {
 		fmt.Println("Error detecting bucket region!", err)

--- a/pkg/aws/s3/s3.go
+++ b/pkg/aws/s3/s3.go
@@ -30,7 +30,7 @@ type Service interface {
 	PutObjectSimple(ctx context.Context, bucketName string, keyName string, body io.Reader) (*string, *string, error)
 
 	// GetBucketRegion will return the region of a bucket
-	GetBucektRegion(ctx context.Context, bucketName string) (string, error)
+	GetBucketRegion(ctx context.Context, bucketName string) (string, error)
 
 	// ListObjects will return some or all (up to 1,000) of the objects in a bucket with each request.
 	// Objects are returned sorted in an ascending order of the respective key names in the list.
@@ -190,7 +190,7 @@ func (s *service) PutObjectSimple(ctx context.Context, bucketName string, keyNam
 	return result.ETag, result.VersionId, nil
 }
 
-func (s *service) GetBucektRegion(ctx context.Context, bucketName string) (string, error) {
+func (s *service) GetBucketRegion(ctx context.Context, bucketName string) (string, error) {
 	log.Debug().Str("bucket", bucketName).Msg("s3: looking up bucket region")
 	result, err := s.client.GetBucketLocation(ctx, &s3.GetBucketLocationInput{
 		Bucket: &bucketName,

--- a/pkg/aws/s3/s3_test.go
+++ b/pkg/aws/s3/s3_test.go
@@ -365,7 +365,7 @@ func Test_s3Service_PutObjectSimple(t *testing.T) {
 	}
 }
 
-func Test_service_GetBucektRegion(t *testing.T) {
+func Test_service_GetBucketRegion(t *testing.T) {
 	log.Logger = log.Output(zerolog.TestWriter{T: t})
 	s3Mock := S3APIMock{
 		options: s3.Options{},
@@ -429,13 +429,13 @@ func Test_service_GetBucektRegion(t *testing.T) {
 				awsEndpoint: tt.fields.awsEndpoint,
 				region:      tt.fields.region,
 			}
-			got, err := s.GetBucektRegion(context.TODO(), tt.bucketName)
+			got, err := s.GetBucketRegion(context.TODO(), tt.bucketName)
 			if (err != nil) != tt.wantErr {
-				t.Errorf("service.GetBucektRegion() error = %v, wantErr %v", err, tt.wantErr)
+				t.Errorf("service.GetBucketRegion() error = %v, wantErr %v", err, tt.wantErr)
 				return
 			}
 			if got != tt.want {
-				t.Errorf("service.GetBucektRegion() = %v, want %v", got, tt.want)
+				t.Errorf("service.GetBucketRegion() = %v, want %v", got, tt.want)
 			}
 		})
 	}

--- a/tools/s3-metrics/main.go
+++ b/tools/s3-metrics/main.go
@@ -91,7 +91,7 @@ func main() {
 	}
 	fmt.Println("")
 
-	bucketRegion, err := s3svc.GetBucektRegion(context.TODO(), selectedBucket)
+	bucketRegion, err := s3svc.GetBucketRegion(context.TODO(), selectedBucket)
 	if err != nil {
 		fmt.Println("Error detecting bucket region!", err)
 		os.Exit(1)


### PR DESCRIPTION
The `GetBucketRegion` function was incorrectly named. This change fixes the spelling error.